### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Elixir world. I've seen many multi-thousand line modules. I've rarely
 seen a Phoenix app where the developers have implemented the business
 logic in other, free-standing apps (and I don't count the things in
 umbrella apps as being free standing, firstly because the individual
-components are not sharable, and secondly because that fact that all the
+components are not shareable, and secondly because that fact that all the
 code is in one place tempts developers to just call randomly between the
 child apps.)
 

--- a/lib/component/code_gen_helper.ex
+++ b/lib/component/code_gen_helper.ex
@@ -1,6 +1,6 @@
 defmodule Component.CodeGenHelper do
   @moduledoc """
-  Functions that help massage one- and two-way funtion definitions
+  Functions that help massage one- and two-way function definitions
   into real code. These are called from the Strategy@impl functions
   in the Strategy.Xxx modules.
   """

--- a/lib/component/strategy.ex
+++ b/lib/component/strategy.ex
@@ -79,7 +79,7 @@ defmodule Component.Strategy do
 
   # Orchestrate the production of code for a particular strategy. We're
   # called after the target module has been parsed but before compilation.
-  # All tne one-way and two-way declarations have been tucked away in the
+  # All the one-way and two-way declarations have been tucked away in the
   # preprocessor state: we extract them and get the individual strategies
   # to generate code.
 

--- a/lib/component/strategy/pooled/supervisor.ex
+++ b/lib/component/strategy/pooled/supervisor.ex
@@ -9,7 +9,7 @@ defmodule Component.Strategy.Pooled.Supervisor do
   `worker_module`: the module containing the code for the worker_module
   `pool`:          a specification for the pool
   `min`: number of prestarted workers
-  `max`: can add upto `max - min` demand-based workers
+  `max`: can add up to `max - min` demand-based workers
   """
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts)

--- a/old_examples/README.md
+++ b/old_examples/README.md
@@ -1,6 +1,6 @@
 # Examples of Components in Use
 
-The `lib/` directoy contains examples of each type of component. Each
+The `lib/` directory contains examples of each type of component. Each
 sample contains two modules. The first is the sample component itself,
 and the second is a set of unit tests that illustrate how that component
 is used.


### PR DESCRIPTION
Found via `codespell -S ./assets`